### PR TITLE
Set default github.token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
         uses: ./
         if: endsWith(github.ref, 'main') == false
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           check_name: Example JUnit Test Report
           report_paths: '**/surefire-reports/TEST-*.xml'
           summary: '<table><thead><tr><th> Application (src/applications) </th></tr></thead><tbody><tr><td> test </td></tr></tbody></table>'
@@ -24,7 +23,6 @@ jobs:
         uses: ./
         if: endsWith(github.ref, 'main') == false
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           check_name: Example Pytest Report
           report_paths: test_results/python/report.xml
       - name: Install NPM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       - '*'
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -66,15 +66,14 @@ jobs:
         uses: mikepenz/action-junit-report@v2
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Inputs
 
 | **Input**      | **Description**                                                                                                                                                       |
 |----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `github_token`    | **Required**. Usually in form of `github_token: ${{ secrets.GITHUB_TOKEN }}`.                                                                                      |
 | `report_paths`    | **Required**. [Glob](https://github.com/actions/toolkit/tree/master/packages/glob) expression to junit report paths. The default is `**/junit-reports/TEST-*.xml`. |
+| `token`    | Optional. GitHub token for creating a check run. Set to `${{ github.token }}` by default.                                                                                     |
 | `check_name`      | Optional. Check name to use when creating a check run. The default is `Test Report`.                                                                               |
 | `suite_regex`     | Optional. Regular expression for the named test suites. E.g. `Test*`                                                                                               |
 | `commit`          | Optional. The commit SHA to update the status. This is useful when you run it with `workflow_run`.                                                                 |

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ branding:
 inputs:
   token:
     description: 'Specify the token to use to publish the check.'
-    required: true
+    required: false
+    default: ${{ github.token }}
   github_token:
     description: 'Deprecated syntax to specify github token.'
     required: true


### PR DESCRIPTION
We can't set it to `secrets.GITHUB_TOKEN` because `secrets` context is not in scope, but `github` context is, so this input doesn't have to be required and can use the provided `github.token` (same as `secrets.GITHUB_TOKEN`) by default.

Note: this doesn't break compatibility for those who set this input explicitly. Also, I didn't touch the deprecated `github_token`.