### PR TITLE
Parse rust tests line number correctly

### DIFF
--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -88,6 +88,20 @@ test.py:14: AttributeError
         expect(fileName).toBe('test.py');
         expect(line).toBe(14);
     });
+
+    it('should parse correctly line number for rust tests', async () => {
+      const { fileName, line } = await resolveFileAndLine(
+        null,
+        'project',
+        `
+                  thread &#x27;project::admission_webhook_tests::it_should_be_possible_to_update_projects&#x27; panicked at &#x27;boom&#x27;, tests/project/admission_webhook_tests.rs:48:38
+note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display a backtrace
+
+  `
+      );
+      expect(line).toBe(48);
+      expect(fileName).toBe('project');
+    });
 });
 
 describe('resolvePath', () => {

--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -4,7 +4,7 @@ import { resolveFileAndLine, resolvePath, parseFile } from '../src/testParser'
  * Original test cases:
  *   Copyright 2020 ScaCap
  *   https://github.com/ScaCap/action-surefire-report/blob/master/utils.test.js
- * 
+ *
  * New test cases:
  *   Copyright Mike Penz
  */
@@ -100,7 +100,7 @@ note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display
   `
       );
       expect(line).toBe(48);
-      expect(fileName).toBe('project');
+      expect(fileName).toBe('tests/project/admission_webhook_tests.rs');
     });
 });
 

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -45,7 +45,7 @@ export async function resolveFileAndLine(
     if (!matches) return {fileName, line: 1}
 
     const [lastItem] = matches.slice(-1)
-    const [, line] = lastItem.split(':')
+    const line = lastItem.split(':').pop() || '0'
     core.debug(`Resolved file ${fileName} and line ${line}`)
 
     return {fileName, line: parseInt(line)}

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -38,14 +38,26 @@ export async function resolveFileAndLine(
   className: string,
   output: String
 ): Promise<Position> {
-  const fileName = file ? file : className.split('.').slice(-1)[0]
+  let fileName = file ? file : className.split('.').slice(-1)[0]
   try {
     const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const matches = output.match(new RegExp(`${escapedFileName}.*?:\\d+`, 'g'))
     if (!matches) return {fileName, line: 1}
 
     const [lastItem] = matches.slice(-1)
-    const line = lastItem.split(':').pop() || '0'
+
+    const lineTokens = lastItem.split(':')
+    const line = lineTokens.pop() || '0'
+
+    // check, if the error message is from a rust file -- this way we have the chance to find
+    // out the involved test file
+    {
+      const lineNumberPrefix = lineTokens.pop() || ''
+      if (lineNumberPrefix.endsWith('.rs')) {
+        fileName = lineNumberPrefix.split(' ').pop() || ''
+      }
+    }
+
     core.debug(`Resolved file ${fileName} and line ${line}`)
 
     return {fileName, line: parseInt(line)}


### PR DESCRIPTION
Rust classes contain colons, so the last colon is not necessarily the
second colon (as the current code expects).

This results in annotations like:

```
...
  annotations: [
    {
      path: 'project::admission_webhook_tests',
      start_line: NaN,
      end_line: NaN,
      start_column: 0,
      end_column: 0,
      annotation_level: 'failure',
      title: 'project::admission_webhook_tests.it_should_be_possible_to_update_projects',
      message: 'failed project::admission_webhook_tests::it_should_be_possible_to_update_projects',
      ...
    },
 ...
```

problem being the `NaN` entries, which are not accepted by github