### PR TITLE
Correctly parse line number from rust tests

### DIFF
--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -88,6 +88,30 @@ test.py:14: AttributeError
         expect(fileName).toBe('test.py');
         expect(line).toBe(14);
     });
+
+    it('should parse correctly line number for rust tests', async () => {
+      const { fileName, line } = await resolveFileAndLine(
+        null,
+        'project',
+        `thread &#x27;project::admission_webhook_tests::it_should_be_possible_to_update_projects&#x27; panicked at &#x27;boom&#x27;, tests/project/admission_webhook_tests.rs:48:38
+note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display a backtrace
+
+  `
+      );
+      expect(line).toBe(48);
+    });
+
+  it('should parse correctly line number for rust tests 2', async () => {
+    const { fileName, line } = await resolveFileAndLine(
+      null,
+      'project::manifest_secrets',
+      `thread 'project::manifest_secrets::it_should_skip_annotated_manifests' panicked at 'assertion failed: \`(left == right)\`\\n" +
+        '  left: \`0\`,\\n' +
+        " right: \`42\`: all manifests should be skipped', tests/project/manifest_secrets.rs:305:5
+  `
+    );
+    expect(line).toBe(305);
+  });
 });
 
 describe('resolvePath', () => {

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -40,12 +40,15 @@ export async function resolveFileAndLine(
 ): Promise<Position> {
   const fileName = file ? file : className.split('.').slice(-1)[0]
   try {
-    const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace('::', '/')
     const matches = output.match(new RegExp(`${escapedFileName}.*?:\\d+`, 'g'))
     if (!matches) return {fileName, line: 1}
 
     const [lastItem] = matches.slice(-1)
-    const [, line] = lastItem.split(':')
+
+    const lineTokens = lastItem.split(':')
+    const line = lineTokens.pop() || '0'
+
     core.debug(`Resolved file ${fileName} and line ${line}`)
 
     return {fileName, line: parseInt(line)}


### PR DESCRIPTION
Rust test output contains colons between package names, i.e. taking the
second item of a split on ':' does not work. Instead use the last item
of the split.