### PR TITLE
Feature/parse rust filenames correctly

### DIFF
--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -4,7 +4,7 @@ import { resolveFileAndLine, resolvePath, parseFile } from '../src/testParser'
  * Original test cases:
  *   Copyright 2020 ScaCap
  *   https://github.com/ScaCap/action-surefire-report/blob/master/utils.test.js
- * 
+ *
  * New test cases:
  *   Copyright Mike Penz
  */
@@ -99,6 +99,7 @@ note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display
   `
       );
       expect(line).toBe(48);
+      expect(fileName).toBe('tests/project/admission_webhook_tests.rs');
     });
 
   it('should parse correctly line number for rust tests 2', async () => {
@@ -111,6 +112,7 @@ note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display
   `
     );
     expect(line).toBe(305);
+    expect(fileName).toBe('tests/project/manifest_secrets.rs');
   });
 });
 

--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -88,6 +88,30 @@ test.py:14: AttributeError
         expect(fileName).toBe('test.py');
         expect(line).toBe(14);
     });
+
+    it('should parse correctly line number for rust tests', async () => {
+      const { fileName, line } = await resolveFileAndLine(
+        null,
+        'project',
+        `thread &#x27;project::admission_webhook_tests::it_should_be_possible_to_update_projects&#x27; panicked at &#x27;boom&#x27;, tests/project/admission_webhook_tests.rs:48:38
+note: run with &#x60;RUST_BACKTRACE&#x3D;1&#x60; environment variable to display a backtrace
+
+  `
+      );
+      expect(line).toBe(48);
+    });
+
+  it('should parse correctly line number for rust tests 2', async () => {
+    const { fileName, line } = await resolveFileAndLine(
+      null,
+      'project::manifest_secrets',
+      `thread 'project::manifest_secrets::it_should_skip_annotated_manifests' panicked at 'assertion failed: \`(left == right)\`\\n" +
+        '  left: \`0\`,\\n' +
+        " right: \`42\`: all manifests should be skipped', tests/project/manifest_secrets.rs:305:5
+  `
+    );
+    expect(line).toBe(305);
+  });
 });
 
 describe('resolvePath', () => {

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -38,16 +38,30 @@ export async function resolveFileAndLine(
   className: string,
   output: String
 ): Promise<Position> {
-  const fileName = file ? file : className.split('.').slice(-1)[0]
+  let fileName = file ? file : className.split('.').slice(-1)[0]
   try {
-    const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace('::', '/')
-    const matches = output.match(new RegExp(`${escapedFileName}.*?:\\d+`, 'g'))
+    const escapedFileName = fileName
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      .replace('::', '/')
+
+    const matches = output.match(
+      new RegExp(` [^ ]*${escapedFileName}.*?:\\d+`, 'g')
+    )
     if (!matches) return {fileName, line: 1}
 
     const [lastItem] = matches.slice(-1)
 
     const lineTokens = lastItem.split(':')
     const line = lineTokens.pop() || '0'
+
+    // check, if the error message is from a rust file -- this way we have the chance to find
+    // out the involved test file
+    {
+      const lineNumberPrefix = lineTokens.pop() || ''
+      if (lineNumberPrefix.endsWith('.rs')) {
+        fileName = lineNumberPrefix.split(' ').pop() || ''
+      }
+    }
 
     core.debug(`Resolved file ${fileName} and line ${line}`)
 

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -40,12 +40,15 @@ export async function resolveFileAndLine(
 ): Promise<Position> {
   const fileName = file ? file : className.split('.').slice(-1)[0]
   try {
-    const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace('::', '/')
     const matches = output.match(new RegExp(`${escapedFileName}.*?:\\d+`, 'g'))
     if (!matches) return {fileName, line: 1}
 
     const [lastItem] = matches.slice(-1)
-    const [, line] = lastItem.split(':')
+
+    const lineTokens = lastItem.split(':')
+    const line = lineTokens.pop() || '0'
+
     core.debug(`Resolved file ${fileName} and line ${line}`)
 
     return {fileName, line: parseInt(line)}


### PR DESCRIPTION
depends on https://github.com/mikepenz/action-junit-report/pull/359

Splitting line number parsing and file name parsing as the file name parsing happens at an usual place -- I am not sure whether this should happen somewhere else

When cargo2junit, the filenames are not encoded in the xml, i.e. parse
them analogue to line number parsing.

