### PR TITLE
Add new testcase for junit web test runner output

### DIFF
--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -462,4 +462,24 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
               }
         ]);
     });
+
+    it('should parse junit web test results', async () => {
+        const { count, skipped, annotations } = await parseFile('test_results/junit-web-test/expected.xml');
+
+        expect(count).toBe(6);
+        expect(skipped).toBe(1);
+        expect(annotations).toStrictEqual([
+            {
+                path: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js",
+                start_line: 15,
+                end_line: 15,
+                start_column: 0,
+                end_column: 0,
+                annotation_level: "failure",
+                title: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js.asserts error",
+                message: "expected false to be true",
+                raw_details: "AssertionError: expected false to be true\n  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)",
+            }
+        ]);
+    });
 });

--- a/test_results/junit-web-test/expected.xml
+++ b/test_results/junit-web-test/expected.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a" file="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
+  </testsuite>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="0.001">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" line="15">
+      <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)]]></failure>
+    </testcase>
+    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js">
+      <skipped/>
+    </testcase>
+    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
- add new testcase to check junit web test runner output parsing
  - FIX https://github.com/mikepenz/action-junit-report/issues/458
  - uses expected.xml output from https://github.com/modernweb-dev/web/pull/1824