### PR TITLE
JUnit retries are handled as passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,18 @@ jobs:
 
 ### Inputs
 
-| **Input**      | **Description**                                                                                                                                                       |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Input**      | **Description**                                                                                                                                                    |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `report_paths`    | **Required**. [Glob](https://github.com/actions/toolkit/tree/master/packages/glob) expression to junit report paths. The default is `**/junit-reports/TEST-*.xml`. |
 | `token`           | Optional. GitHub token for creating a check run. Set to `${{ github.token }}` by default.                                                                          |
-| `exclude_sources` | Optional. Provide `,` seperated array of folders to ignore for source lookup. Defaults to: `/build/,/__pycache__/`                                                  |
+| `exclude_sources` | Optional. Provide `,` seperated array of folders to ignore for source lookup. Defaults to: `/build/,/__pycache__/`                                                 |
 | `check_name`      | Optional. Check name to use when creating a check run. The default is `JUnit Test Report`.                                                                         |
 | `suite_regex`     | Optional. Regular expression for the named test suites. E.g. `Test*`                                                                                               |
 | `commit`          | Optional. The commit SHA to update the status. This is useful when you run it with `workflow_run`.                                                                 |
 | `fail_on_failure` | Optional. Fail the build in case of a test failure.                                                                                                                |
 | `require_tests`   | Optional. Fail if no test are found..                                                                                                                              |
-| `check_title_template`  | Optional. Template to configure the title format. Placeholders: ${{FILE_NAME}}, ${{SUITE_NAME}}, ${{TEST_NAME}}.                                             |
+| `check_retries`   | Optional. If a testcase is retried, ignore the original failure.                                                                                                   |
+| `check_title_template`  | Optional. Template to configure the title format. Placeholders: ${{FILE_NAME}}, ${{SUITE_NAME}}, ${{TEST_NAME}}.                                                   |
 | `summary`         | Optional. Additional text to summary output                                                                                                                        |
 
 ## Sample 🖥️

--- a/__tests__/testParser.test.ts
+++ b/__tests__/testParser.test.ts
@@ -152,6 +152,7 @@ describe('parseFile', () => {
         expect(annotations).toStrictEqual([
             {
                 path: 'test_results/tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
+                testcase: "test error handling",
                 start_line: 27,
                 end_line: 27,
                 start_column: 0,
@@ -165,6 +166,7 @@ describe('parseFile', () => {
             },
             {
                 path: 'test_results/tests/utils/src/test/java/action/surefire/report/calc/CalcUtilsTest.kt',
+                testcase: "test scale",
                 start_line: 15,
                 end_line: 15,
                 start_column: 0,
@@ -185,6 +187,7 @@ describe('parseFile', () => {
         expect(annotations).toStrictEqual([
             {
                 path: 'test_results/python/test_sample.py',
+                testcase: 'test_which_fails',
                 start_line: 10,
                 end_line: 10,
                 start_column: 0,
@@ -197,6 +200,7 @@ describe('parseFile', () => {
             },
             {
                 path: 'test_results/python/test_sample.py',
+                testcase: 'test_with_error',
                 start_line: 14,
                 end_line: 14,
                 start_column: 0,
@@ -226,6 +230,7 @@ describe('parseFile', () => {
         expect(annotations).toStrictEqual([
             {
                 "annotation_level": "failure",
+                "testcase": 'test_01',
                 "end_column": 0,
                 "end_line": 1,
                 "message": "test_01",
@@ -246,6 +251,7 @@ describe('parseFile', () => {
         expect(annotations).toStrictEqual([
             {
                 "annotation_level": "failure",
+                "testcase": 'test_01_dummy',
                 "end_column": 0,
                 "end_line": 1,
                 "message": "java.io.FileNotFoundException: No content provider: content://com.xyz/photo.jpg\nat android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1969)",
@@ -274,6 +280,7 @@ describe('parseFile', () => {
         expect(annotations).toStrictEqual([
             {
                 "annotation_level": "failure",
+                "testcase": "loadFromXMLString_When_Should2Test",
                 "end_column": 0,
                 "end_line": 1,
                 "message": "false == something.loadXml(xml_string)",
@@ -308,6 +315,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
         expect(skipped).toBe(0);
         expect(annotations).toStrictEqual([{
             "path": "A",
+            "testcase": "A",
             "start_line": 1,
             "end_line": 1,
             "start_column": 0,
@@ -318,6 +326,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             "raw_details": ""
         }, {
             "path": "B",
+            "testcase": "B",
             "start_line": 1,
             "end_line": 1,
             "start_column": 0,
@@ -328,6 +337,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             "raw_details": ""
         }, {
             "path": "A",
+            "testcase": "A",
             "start_line": 1,
             "end_line": 1,
             "start_column": 0,
@@ -346,6 +356,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
         expect(skipped).toBe(10);
         expect(annotations).toStrictEqual([{
             path: "factorial_of_value_from_fixture",
+            testcase: "factorial_of_value_from_fixture",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -356,6 +367,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             raw_details: "",
           }, {
             path: "factorial_of_value_from_fixture[0]",
+            testcase: "factorial_of_value_from_fixture[0]",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -366,6 +378,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             raw_details: "",
           }, {
             path: "positive_arguments_must_produce_expected_result",
+            testcase: "positive_arguments_must_produce_expected_result",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -376,6 +389,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             raw_details: "",
           }, {
             path: "positive_arguments_must_produce_expected_result[2]",
+            testcase: "positive_arguments_must_produce_expected_result[2]",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -386,6 +400,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             raw_details: "",
           }, {
             path: "test_which_fails_check_eq_with_custom_message",
+            testcase: "test_which_fails_check_eq_with_custom_message",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -396,6 +411,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
             raw_details: "",
           }, {
             path: "test_which_throws_unknown_exception",
+            testcase: "test_which_throws_unknown_exception",
             start_line: 1,
             end_line: 1,
             start_column: 0,
@@ -414,6 +430,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
         expect(skipped).toBe(0);
         expect(annotations).toStrictEqual([{
             "path": "/path/test/config.js",
+            "testcase": "Config files default config projectUTCOffset should be a callable with current UTC offset",
             "start_line": 1,
             "end_line": 1,
             "start_column": 0,
@@ -426,12 +443,13 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
     });
 
     it('parse mocha test case, custom title template', async () => {
-        const { count, skipped, annotations } = await parseFile('test_results/mocha/mocha.xml', '*', true, ['/build/', '/__pycache__/'], '${{TEST_NAME}}');
+        const { count, skipped, annotations } = await parseFile('test_results/mocha/mocha.xml', '*', true, ['/build/', '/__pycache__/'], false, '${{TEST_NAME}}');
 
         expect(count).toBe(1);
         expect(skipped).toBe(0);
         expect(annotations).toStrictEqual([{
             "path": "/path/test/config.js",
+            "testcase": "Config files default config projectUTCOffset should be a callable with current UTC offset",
             "start_line": 1,
             "end_line": 1,
             "start_column": 0,
@@ -451,6 +469,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
         expect(annotations).toStrictEqual([
             {
                 path: "main.c",
+                testcase: "test_my_sum_fail",
                 start_line: 38,
                 end_line: 38,
                 start_column: 0,
@@ -471,6 +490,7 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
         expect(annotations).toStrictEqual([
             {
                 path: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js",
+                testcase: "asserts error",
                 start_line: 15,
                 end_line: 15,
                 start_column: 0,
@@ -479,6 +499,60 @@ action.surefire.report.email.InvalidEmailAddressException: Invalid email address
                 title: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js.asserts error",
                 message: "expected false to be true",
                 raw_details: "AssertionError: expected false to be true\n  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)",
+            }
+        ]);
+    });
+
+    it('should handle retries', async () => {
+        const { count, skipped, annotations } = await parseFile('test_results/junit-web-test/expectedRetries.xml', '', false, ['/build/', '/__pycache__/'], true);
+
+        expect(count).toBe(8);
+        expect(skipped).toBe(1);
+        expect(annotations).toStrictEqual([
+            {
+                path: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js",
+                testcase: "asserts error",
+                start_line: 15,
+                end_line: 15,
+                start_column: 0,
+                end_column: 0,
+                annotation_level: "failure",
+                title: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js.asserts error",
+                message: "expected false to be true",
+                raw_details: "AssertionError: expected false to be true\n  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)",
+            }
+        ]);
+    });
+
+    it('there should be two errors if retries are not handled', async () => {
+        const { count, skipped, annotations } = await parseFile('test_results/junit-web-test/expectedRetries.xml');
+
+        expect(count).toBe(8);
+        expect(skipped).toBe(1);
+        expect(annotations).toStrictEqual([
+            {
+                path: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js",
+                testcase: "asserts error",
+                start_line: 15,
+                end_line: 15,
+                start_column: 0,
+                end_column: 0,
+                annotation_level: "failure",
+                title: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js.asserts error",
+                message: "expected false to be true",
+                raw_details: "AssertionError: expected false to be true\n  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)",
+            },
+            {
+                annotation_level: "failure",
+                end_column: 0,
+                end_line: 15,
+                message: "this is flaky, so is retried",
+                path: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js",
+                raw_details: "AssertionError: expected false to be true\n  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)",
+                start_column: 0,
+                start_line: 15,
+                testcase: "retried flaky test",
+                title: "packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js.retried flaky test",
             }
         ]);
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ export async function run(): Promise<void> {
     const excludeSources = core.getInput('exclude_sources')
       ? core.getInput('exclude_sources').split(',')
       : []
+    const checkRetries = core.getInput('check_retries') === 'true'
 
     core.endGroup()
     core.startGroup(`📦 Process test results`)
@@ -38,6 +39,7 @@ export async function run(): Promise<void> {
       suiteRegex,
       includePassed,
       excludeSources,
+      checkRetries,
       checkTitleTemplate
     )
     const foundResults = testResult.count > 0 || testResult.skipped > 0

--- a/test_results/junit-web-test/expectedRetries.xml
+++ b/test_results/junit-web-test/expectedRetries.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js" id="0" tests="1" skipped="0" errors="0" failures="0" time="0.001">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="is equivalent to map (f.g) f a" time="<<computed>>" classname="given a functor f and a function a -&gt; b map f map g f a" file="packages/test-runner-junit-reporter/test/fixtures/multiple/nested-test.js"/>
+  </testsuite>
+  <testsuite name="Chrome_puppeteer_/packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" id="0" tests="5" skipped="1" errors="1" failures="1" time="0.001">
+    <properties>
+      <property name="test.fileName" value="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+      <property name="browser.name" value="Chrome"/>
+      <property name="browser.launcher" value="puppeteer"/>
+    </properties>
+    <testcase name="under addition" time="0.001" classname="real numbers forming a monoid" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="null hypothesis" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+    <testcase name="asserts error" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" line="15">
+      <failure message="expected false to be true" type="AssertionError"><![CDATA[AssertionError: expected false to be true
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)]]></failure>
+    </testcase>
+    <testcase name="retried flaky test" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" line="15">
+      <failure message="this is flaky, so is retried" type="AssertionError"><![CDATA[AssertionError: expected false to be true
+  at o.<anonymous> (packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js:15:29)]]></failure>
+    </testcase>
+    <testcase name="tbd: confirm true positive" time="0" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js">
+      <skipped/>
+    </testcase>
+    <testcase name="retried flaky test" time="0.001" classname="off-by-one boolean logic errors" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js" line="15"/>
+    <testcase name="reports logs to JUnit" time="0.001" classname="logging during a test" file="packages/test-runner-junit-reporter/test/fixtures/multiple/simple-test.js"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
If JUnit is set up to retry tests (in case of flakiness) you get a second
testcase with the same name in the output XML.

This change checks for a second occurrence of the same named testcase in a suite,
and removes the previous failure from the annotations.

It is hidden behind a boolean config item `check_retries`