### PR TITLE
Fix `annotate_only` not yet defined in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Regular expression for the named test suites'
     required: false
     default: ''
+  annotate_only:
+    description: 'Enable to only annotate the results on the files, won't create a check run.'
+    required: false
+    default: 'false'
   update_check:
     description: 'Defines if the active check should be updated instead'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: ''
   annotate_only:
-    description: 'Enable to only annotate the results on the files, won't create a check run.'
+    description: 'Enable to only annotate the results on the files, will not create a check run.'
     required: false
     default: 'false'
   update_check:


### PR DESCRIPTION
- fix action.yml misses new param
  - FIX https://github.com/mikepenz/action-junit-report/issues/523