### PR TITLE
docs: update expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
         run: # execute your tests generating test results
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
-        if: always() # always run even if the previous step fails
+        if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 ```


### PR DESCRIPTION
if a job is aborted or suffers a critical failure, `always()` is not appropriate 

> always
> Causes the step to always execute, and returns true, even when canceled. The always expression is best used at the step level or on tasks that you expect to run even when a job is canceled. For example, you can use always to send logs even when a job is canceled.



> Note: Avoid using always for any task that could suffer from a critical failure, for example: getting sources, otherwise the workflow may hang until it times out. If you want to run a job or step regardless of its success or failure, use the recommended alternative:if: success() || failure()

Source: https://docs.github.com/en/actions/learn-github-actions/expressions#always

