### PR TITLE
Change deprecated `github_token` to be not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: ${{ github.token }}
   github_token:
     description: 'Deprecated syntax to specify github token.'
-    required: true
+    required: false
   report_paths:
     description: 'Xml report paths in glob format'
     required: false


### PR DESCRIPTION
If you are willing to fix it in #830, please merge this PR.