### PR TITLE
Fix: Apply transformers to FILE_NAME in check_title_template

### DIFF
--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -510,7 +510,7 @@ async function createTestCaseAnnotation(
   let title = ''
   if (checkTitleTemplate) {
     // ensure to not duplicate the test_name if file_name is equal
-    const fileName = pos.fileName !== testcase._attributes.name ? pos.fileName : ''
+    const fileName = pos.fileName !== testcase._attributes.name ? transformedFileName : ''
     const baseClassName = testcase._attributes.classname ? testcase._attributes.classname : testcase._attributes.name
     const className = baseClassName.split('.').slice(-1)[0]
     title = checkTitleTemplate


### PR DESCRIPTION
When using transformers in combination with check_title_template, the {{FILE_NAME}} placeholder was not being replaced with the transformed filename in the summary table, while it worked correctly in console logs.

Root cause: In createTestCaseAnnotation(), the fileName variable used for template replacement was set to pos.fileName (original, untransformed), while the console logs used resolvedPath (which had transformers applied).

This fix changes line 513 in src/testParser.ts to use transformedFileName instead of pos.fileName, ensuring transformers are applied consistently across both summary tables and console output.

Added comprehensive tests to verify transformers work correctly with check_title_template, including single and multiple transformer scenarios.

Fixes #692