### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "js-yaml": "^4.1.1",
         "nock": "^14.0.11",
         "prettier": "^3.8.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.0",
         "vitest": "^4.1.2",
         "webpack": "^5.105.3"
       }
@@ -3558,6 +3558,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-plugin-github/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/eslint-plugin-i18n-text": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-text/-/eslint-plugin-i18n-text-1.0.1.tgz",
@@ -6710,9 +6724,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "js-yaml": "^4.1.1",
         "nock": "^14.0.11",
         "prettier": "^3.8.1",
-        "typescript": "^6.0.0",
+        "typescript": "6.0.2",
         "vitest": "^4.1.2",
         "webpack": "^5.105.3"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "^4.1.1",
     "nock": "^14.0.11",
     "prettier": "^3.8.1",
-    "typescript": "^6.0.0",
+    "typescript": "6.0.2",
     "vitest": "^4.1.2",
     "webpack": "^5.105.3"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "^4.1.1",
     "nock": "^14.0.11",
     "prettier": "^3.8.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "vitest": "^4.1.2",
     "webpack": "^5.105.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
       "ESNext",
       "ES2021.String",
       "dom"
+    ],
+    "types": [
+      "node"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## Summary

- Upgrade TypeScript from 5.9.3 to 6.0.2
- Added `"types": ["node"]` to `tsconfig.json` (required by TS 6)
- No source code changes were needed

## Verification

- Build (`tsc`): passes
- Package (`ncc build`): passes
- Tests (`vitest`): all 73 tests pass (5 test files)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm dist output works correctly in a test workflow