### PR TITLE
chore: simplify renovate config to extend shared convention

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,31 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "pinDigests": true,
-  "osvVulnerabilityAlerts": true,
-  "vulnerabilityAlerts": {
-    "labels": ["dependencies", "security"],
-    "automerge": false,
-    "minimumReleaseAge": "0 days"
-  },
-  "labels": ["dependencies"],
-  "minimumReleaseAge": "7 days",
-  "packageRules": [
-    {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "platformAutomerge": true,
-      "groupName": "devDependency non-major updates",
-      "labels": ["dependencies", "javascript"]
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "automerge": false,
-      "groupName": "GitHub Actions updates",
-      "labels": ["dependencies", "github-actions"]
-    }
-  ],
-  "schedule": ["before 4am on Monday"],
-  "timezone": "Europe/Berlin"
+    "$schema": "https://docs.renovateapp.com/renovate-schema.json",
+    "extends": [
+        "local>mikepenz/convention"
+    ]
 }


### PR DESCRIPTION
## Summary
- Replace repo-local renovate config with a minimal one that extends the shared `mikepenz/convention` preset, matching https://github.com/mikepenz/agent-approver/blob/main/renovate.json.

## Test plan
- [ ] Renovate picks up the new config on next run