### PR TITLE
fix: close empty table cells in generated HTML

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import {readTransformers} from '../src/utils.js'
+import {buildTable, readTransformers} from '../src/utils.js'
 import {describe, expect, it} from 'vitest'
 
 /**
@@ -32,5 +32,13 @@ describe('readTransformers', () => {
         replaceValue: '.t'
       }
     ])
+  })
+})
+
+describe('buildTable', () => {
+  it('should close empty cells', async () => {
+    expect(buildTable([[{data: '', header: true}, {data: 'Tests', header: true}], ['', 'A']])).toStrictEqual(
+      '<table><tr><th></th><th>Tests</th></tr><tr><td></td><td>A</td></tr></table>'
+    )
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,8 @@ function wrap(tag: string, content: string | null, attrs: {[attribute: string]: 
     .map(([key, value]) => ` ${key}="${value}"`)
     .join('')
 
-  if (!content) {
+  // only void tags (explicit `null` content) are self-closing; an empty string still needs a closing tag
+  if (content === null) {
     return `<${tag}${htmlAttrs}>`
   }
 


### PR DESCRIPTION
The summary table's leading blank header cell rendered as an unclosed `<th>`:

```html
<table><tr><th><th>Tests</th><th>Passed ✅</th>…
```

`wrap()` in `src/utils.ts` used `if (!content)` to self-close void tags, which also caught empty-string content. Changed to `content === null` — void tags still self-close, empty cells now get their closing tag.

Affects every empty cell, not just the summary header. GitHub's parser recovers from this, but the emitted HTML is also exposed via the `summary` / `detailed_summary` / `flaky_summary` outputs, where consumers may be stricter.

Test added in `__tests__/utils.test.ts`.