### PR TITLE
ci: add OpenSSF Scorecard, top-level permissions, fix script injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     if: github.event_name  == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -48,12 +50,16 @@ jobs:
           node-version: 24.x
       - run: npm ci && npm run build && npm run package
       - name: Commit rebuilt dist
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
         run: |
           git config user.name "Mike Penz"
           git config user.email "opensource-bot@mikepenz.dev"
           git add dist/
           git diff --staged --quiet || git commit -m "chore: rebuild dist for renovate"
-          git push https://x-access-token:${{ secrets.RENOVATE_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.event.pull_request.head.ref }}
+          git push "https://x-access-token:${RENOVATE_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:refs/heads/${HEAD_REF}"
 
   test:
     if: >

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: '15 2 * * 6'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: "Scorecard"
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 4 * * 1'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF results to code scanning
+      id-token: write # publish the results to the OpenSSF API (badge)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload to code scanning"
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
   <a href="https://github.com/mikepenz/action-junit-report">
 		<img src="https://github.com/mikepenz/action-junit-report/workflows/CI/badge.svg"/>
 	</a>
+	<a href="https://scorecard.dev/viewer/?uri=github.com/mikepenz/action-junit-report">
+		<img src="https://api.scorecard.dev/projects/github.com/mikepenz/action-junit-report/badge"/>
+	</a>
 </div>
 <br />
 


### PR DESCRIPTION
Same hardening pass applied to `release-changelog-builder-action` (#1647, #1648, #1649, #1651), rolled onto this repo.

### Scorecard

New `.github/workflows/scorecard.yml` — weekly, on push to `main`, and on branch protection rule changes. `publish_results: true` feeds the OpenSSF API so the badge and deps.dev pick it up; SARIF goes to code scanning so findings land in the Security tab.

`main` is this repo's default branch (confirmed via the API, not a local ref — `scorecard-action` hard-fails with `only default branch is supported` otherwise).

### Script injection

`build.yml` interpolated `github.event.pull_request.head.ref` straight into the `commit-dist` push command, in a job holding `contents: write` and `secrets.RENOVATE_TOKEN`.

Exploitability was low: the job is gated to same-repo `renovate/` branches created by the repo owner or `renovate-mike[bot]`, so an attacker needs push access first. Still a real sink.

`HEAD_REF` / `REPOSITORY` / `RENOVATE_TOKEN` now go through `env:`, and the push target is an explicit `refs/heads/${HEAD_REF}`.

The `ref:` input on `actions/checkout` is unaffected — that is a `with:` input, not shell. The `annotate_only: ${{ github.event_name == 'workflow_dispatch' }}` expressions in the test jobs are also fine — they are `with:` inputs evaluating to a boolean, with no attacker-controlled text.

### Top-level permissions

`permissions: {}` added to `build.yml` and `codeql-analysis.yml`. All 6 existing jobs already declare their own, so nothing changes today; a future job that forgets one now fails closed instead of inheriting the repository default. Verified by parsing each workflow:

```
.github/workflows/build.yml: top={} jobs=4 missing_job_perms=[]
.github/workflows/codeql-analysis.yml: top={} jobs=1 missing_job_perms=[]
.github/workflows/scorecard.yml: top='read-all' jobs=1 missing_job_perms=[]
```

The CI badge is untouched — it currently renders `CI - passing`, so there was nothing to fix.